### PR TITLE
Add authentication by .cookie on example.env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@
 # Bitcoin RPC Configuration (Example - for future use)
 # BITCOIN_RPC_HOST=127.0.0.1
 # BITCOIN_RPC_PORT=8332 # mainnet, 18332 for testnet, 18443 for regtest
+
+## Just choose ONE! what you use. BITCOIN_RPC_COOKIE if use rpcauth on bitcoin.conf.
+# BITCOIN_RPC_COOKIE=/data/bitcoin/.cookie   # set your bitcoin .cookie file directory (testnet4 directory: /data/bitcoin/testnet4/.cookie )
+## OR choose
 # BITCOIN_RPC_USER=your_rpc_user
 # BITCOIN_RPC_PASSWORD=your_rpc_password
 


### PR DESCRIPTION
For people actually use rpcauth option on bitcoin.conf instead of rpcuser & rpcpassword
![mesht](https://github.com/user-attachments/assets/6ed08aaf-2e58-4335-b2f2-b0b235d0324c)
